### PR TITLE
Add zip php extension requirement

### DIFF
--- a/requirements/index.md
+++ b/requirements/index.md
@@ -44,6 +44,7 @@ title: Hosting requirements
    * apcu
    * apcu-bc
    * exif
+   * zip
 
 ### PHP settings
 


### PR DESCRIPTION
Zip extension is required by ckeditor to install assets.