### PR TITLE
doc: remove 109.190.225.66 from authorized IP addresses

### DIFF
--- a/docs/config/base.md
+++ b/docs/config/base.md
@@ -27,7 +27,6 @@ La liste des clés publiques des utilisateurs du Phare est disponible à l'adres
 
 La liste des adresses ips à autoriser :
  * 37.59.114.65
- * 109.190.225.66
  * 193.39.2.4
  * 80.15.143.1
 


### PR DESCRIPTION
Les mots de @caillaudv :

> C'était notre ancienne IP OVH Téléphone de mémoire qui pouvait servir de 2eme backup mais on devrait la supprimer de nos prérequis elle en sert plus.