### PR TITLE
docs(config): add python requirement

### DIFF
--- a/docs/config/base.md
+++ b/docs/config/base.md
@@ -38,6 +38,7 @@ La liste des adresses ips à autoriser :
  - curl
  - rsync (utilisé par lephare/ansible-deploy)
  - pg_dump (utilisé par lephare/ansible-deploy)
+ - Python 2.7, or Python 3.5 - 3.11, pré-requis pour [managed node Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#managed-node-requirements)
 
 ## Droits
 

--- a/index.md
+++ b/index.md
@@ -20,6 +20,10 @@ Ce site présente les configurations nécessaires à l'hébergement des projets 
 
 ## Changements
 
+### 2023-10-02
+
+* ajouts binaire "python" dans la configuration commune.
+
 ### 2023-09-29
 
 * ajouts des sections "Droits" et "Logs"


### PR DESCRIPTION
Nous utilisons Ansible pour déployer une web app, qui requiert python pour le managed node.