### PR TITLE
Php cs fixer 154

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -6,9 +6,15 @@ $finder = PhpCsFixer\Finder::create()
 
 return (new PhpCsFixer\Config())
     ->setRules([
-        '@PhpCsFixer' => true,
+        '@PHP71Migration' => true,
+        '@PHPUnit75Migration:risky' => true,
         '@Symfony' => true,
+        '@Symfony:risky' => true,
+        'protected_to_private' => false,
+        'nullable_type_declaration' => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays', 'match', 'parameters']],
     ])
+    ->setRiskyAllowed(true)
     ->setFinder($finder)
     ->setCacheFile('.php-cs-fixer.cache')
 ;

--- a/.spells
+++ b/.spells
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function php-cs-fixer() {
-    docker run --init -it --rm -v "$(pwd):/project" -v "$(pwd)/tmp-phpqa:/tmp" -w /project jakzal/phpqa php-cs-fixer fix -v --no-interaction tools/
+    docker run --init -it --rm -v "$(pwd):/project" -v "$(pwd)/tmp-phpqa:/tmp" -w /project ghcr.io/php-cs-fixer/php-cs-fixer:3-php8.3 fix -v   tools/
 }
 
 function phpstan() {

--- a/tools/templates/template.md.php
+++ b/tools/templates/template.md.php
@@ -104,7 +104,7 @@ Extensions supplémentaires pour nos applications
 <?php
   foreach ($versionData->settings as $key => $value) {
       if ('_' != substr($key, 0, 1)) {
-          if ('<' == $value[0] or '>' == $value[0]) {
+          if ('<' == $value[0] || '>' == $value[0]) {
               if ('=' == $value[1]) {
                   $value = substr($value, 2);
               } else {


### PR DESCRIPTION
Nouvelle version de php-cs-fixer. Nouvelles règles dans .php-cs-fixer.dist.php et fonction dans .spells, qui sera toujours au même nom. Lancement du fix et génération des nouveaux fichiers. 