### PR TITLE
draft: docs: note about pcntl PHP extension

### DIFF
--- a/docs/generated/versions_pages/10.0.md
+++ b/docs/generated/versions_pages/10.0.md
@@ -81,7 +81,7 @@ Pré-requis pour Symfony 7.x. Ces extensions sont activées par défaut.
 
 Extensions supplémentaires pour nos applications
 * opcache - not tested by check_script
-* pcntl - not tested by check_script
+* pcntl - enabled by default in Debian package - not tested by check_script
 * apcu
 * curl
 * exif

--- a/docs/generated/versions_pages/10.1.md
+++ b/docs/generated/versions_pages/10.1.md
@@ -81,7 +81,7 @@ Pré-requis pour Symfony 7.x. Ces extensions sont activées par défaut.
 
 Extensions supplémentaires pour nos applications
 * opcache - not tested by check_script
-* pcntl - not tested by check_script
+* pcntl - enabled by default in Debian package - not tested by check_script
 * apcu
 * curl
 * exif

--- a/docs/generated/versions_pages/2022.01.md
+++ b/docs/generated/versions_pages/2022.01.md
@@ -81,7 +81,7 @@ Pré-requis pour Symfony 7.x. Ces extensions sont activées par défaut.
 
 Extensions supplémentaires pour nos applications
 * opcache - not tested by check_script
-* pcntl - not tested by check_script
+* pcntl - enabled by default in Debian package - not tested by check_script
 * apcu
 * curl
 * exif

--- a/docs/generated/versions_pages/2022.07.md
+++ b/docs/generated/versions_pages/2022.07.md
@@ -81,7 +81,7 @@ Pré-requis pour Symfony 7.x. Ces extensions sont activées par défaut.
 
 Extensions supplémentaires pour nos applications
 * opcache - not tested by check_script
-* pcntl - not tested by check_script
+* pcntl - enabled by default in Debian package - not tested by check_script
 * apcu
 * curl
 * exif

--- a/docs/generated/versions_pages/2023.04.md
+++ b/docs/generated/versions_pages/2023.04.md
@@ -81,7 +81,7 @@ Pré-requis pour Symfony 7.x. Ces extensions sont activées par défaut.
 
 Extensions supplémentaires pour nos applications
 * opcache - not tested by check_script
-* pcntl - not tested by check_script
+* pcntl - enabled by default in Debian package - not tested by check_script
 * apcu
 * curl
 * exif

--- a/docs/generated/versions_pages/2023.06.md
+++ b/docs/generated/versions_pages/2023.06.md
@@ -81,7 +81,7 @@ Pré-requis pour Symfony 7.x. Ces extensions sont activées par défaut.
 
 Extensions supplémentaires pour nos applications
 * opcache - not tested by check_script
-* pcntl - not tested by check_script
+* pcntl - enabled by default in Debian package - not tested by check_script
 * apcu
 * curl
 * exif

--- a/docs/generated/versions_pages/2024.04.md
+++ b/docs/generated/versions_pages/2024.04.md
@@ -80,7 +80,7 @@ Pré-requis pour Symfony 7.x. Ces extensions sont activées par défaut.
 
 Extensions supplémentaires pour nos applications
 * opcache - not tested by check_script
-* pcntl - not tested by check_script
+* pcntl - enabled by default in Debian package - not tested by check_script
 * apcu
 * curl
 * exif

--- a/docs/generated/versions_pages/2024.07.md
+++ b/docs/generated/versions_pages/2024.07.md
@@ -80,7 +80,7 @@ Pré-requis pour Symfony 7.x. Ces extensions sont activées par défaut.
 
 Extensions supplémentaires pour nos applications
 * opcache - not tested by check_script
-* pcntl - not tested by check_script
+* pcntl - enabled by default in Debian package - not tested by check_script
 * apcu
 * curl
 * exif

--- a/docs/generated/versions_pages/9.0.md
+++ b/docs/generated/versions_pages/9.0.md
@@ -81,7 +81,7 @@ Pré-requis pour Symfony 7.x. Ces extensions sont activées par défaut.
 
 Extensions supplémentaires pour nos applications
 * opcache - not tested by check_script
-* pcntl - not tested by check_script
+* pcntl - enabled by default in Debian package - not tested by check_script
 * apcu
 * curl
 * exif

--- a/docs/generated/versions_tests_scripts/check_10.0.php
+++ b/docs/generated/versions_tests_scripts/check_10.0.php
@@ -31,7 +31,7 @@ $versionData = json_decode('{
     "debian_version": 10,
     "faros_requirements": [
         "_opcache - not tested by check_script",
-        "_pcntl - not tested by check_script",
+        "_pcntl - enabled by default in Debian package - not tested by check_script",
         "apcu",
         "curl",
         "exif",

--- a/docs/generated/versions_tests_scripts/check_10.1.php
+++ b/docs/generated/versions_tests_scripts/check_10.1.php
@@ -31,7 +31,7 @@ $versionData = json_decode('{
     "debian_version": 10,
     "faros_requirements": [
         "_opcache - not tested by check_script",
-        "_pcntl - not tested by check_script",
+        "_pcntl - enabled by default in Debian package - not tested by check_script",
         "apcu",
         "curl",
         "exif",

--- a/docs/generated/versions_tests_scripts/check_2022.01.php
+++ b/docs/generated/versions_tests_scripts/check_2022.01.php
@@ -31,7 +31,7 @@ $versionData = json_decode('{
     "debian_version": 11.2,
     "faros_requirements": [
         "_opcache - not tested by check_script",
-        "_pcntl - not tested by check_script",
+        "_pcntl - enabled by default in Debian package - not tested by check_script",
         "apcu",
         "curl",
         "exif",

--- a/docs/generated/versions_tests_scripts/check_2022.07.php
+++ b/docs/generated/versions_tests_scripts/check_2022.07.php
@@ -31,7 +31,7 @@ $versionData = json_decode('{
     "debian_version": 11.3,
     "faros_requirements": [
         "_opcache - not tested by check_script",
-        "_pcntl - not tested by check_script",
+        "_pcntl - enabled by default in Debian package - not tested by check_script",
         "apcu",
         "curl",
         "exif",

--- a/docs/generated/versions_tests_scripts/check_2023.04.php
+++ b/docs/generated/versions_tests_scripts/check_2023.04.php
@@ -31,7 +31,7 @@ $versionData = json_decode('{
     "debian_version": 11.6,
     "faros_requirements": [
         "_opcache - not tested by check_script",
-        "_pcntl - not tested by check_script",
+        "_pcntl - enabled by default in Debian package - not tested by check_script",
         "apcu",
         "curl",
         "exif",

--- a/docs/generated/versions_tests_scripts/check_2023.06.php
+++ b/docs/generated/versions_tests_scripts/check_2023.06.php
@@ -31,7 +31,7 @@ $versionData = json_decode('{
     "debian_version": 12,
     "faros_requirements": [
         "_opcache - not tested by check_script",
-        "_pcntl - not tested by check_script",
+        "_pcntl - enabled by default in Debian package - not tested by check_script",
         "apcu",
         "curl",
         "exif",

--- a/docs/generated/versions_tests_scripts/check_2024.04.php
+++ b/docs/generated/versions_tests_scripts/check_2024.04.php
@@ -31,7 +31,7 @@ $versionData = json_decode('{
     "debian_version": 12,
     "faros_requirements": [
         "_opcache - not tested by check_script",
-        "_pcntl - not tested by check_script",
+        "_pcntl - enabled by default in Debian package - not tested by check_script",
         "apcu",
         "curl",
         "exif",

--- a/docs/generated/versions_tests_scripts/check_2024.07.php
+++ b/docs/generated/versions_tests_scripts/check_2024.07.php
@@ -31,7 +31,7 @@ $versionData = json_decode('{
     "debian_version": 12,
     "faros_requirements": [
         "_opcache - not tested by check_script",
-        "_pcntl - not tested by check_script",
+        "_pcntl - enabled by default in Debian package - not tested by check_script",
         "apcu",
         "curl",
         "exif",

--- a/docs/generated/versions_tests_scripts/check_9.0.php
+++ b/docs/generated/versions_tests_scripts/check_9.0.php
@@ -31,7 +31,7 @@ $versionData = json_decode('{
     "debian_version": 9,
     "faros_requirements": [
         "_opcache - not tested by check_script",
-        "_pcntl - not tested by check_script",
+        "_pcntl - enabled by default in Debian package - not tested by check_script",
         "apcu",
         "curl",
         "exif",

--- a/versions_data/10.0(2019.10).json
+++ b/versions_data/10.0(2019.10).json
@@ -5,7 +5,7 @@
     "debian_version": 10,
     "faros_requirements": [
         "_opcache - not tested by check_script",
-        "_pcntl - not tested by check_script",
+        "_pcntl - enabled by default in Debian package - not tested by check_script",
         "apcu",
         "curl",
         "exif",

--- a/versions_data/10.1(2021.03).json
+++ b/versions_data/10.1(2021.03).json
@@ -5,7 +5,7 @@
     "debian_version": 10,
     "faros_requirements": [
         "_opcache - not tested by check_script",
-        "_pcntl - not tested by check_script",
+        "_pcntl - enabled by default in Debian package - not tested by check_script",
         "apcu",
         "curl",
         "exif",

--- a/versions_data/2022.01.json
+++ b/versions_data/2022.01.json
@@ -5,7 +5,7 @@
     "debian_version": 11.2,
     "faros_requirements": [
         "_opcache - not tested by check_script",
-        "_pcntl - not tested by check_script",
+        "_pcntl - enabled by default in Debian package - not tested by check_script",
         "apcu",
         "curl",
         "exif",

--- a/versions_data/2022.07.json
+++ b/versions_data/2022.07.json
@@ -5,7 +5,7 @@
     "debian_version": 11.3,
     "faros_requirements": [
         "_opcache - not tested by check_script",
-        "_pcntl - not tested by check_script",
+        "_pcntl - enabled by default in Debian package - not tested by check_script",
         "apcu",
         "curl",
         "exif",

--- a/versions_data/2023.04.json
+++ b/versions_data/2023.04.json
@@ -5,7 +5,7 @@
     "debian_version": 11.6,
     "faros_requirements": [
         "_opcache - not tested by check_script",
-        "_pcntl - not tested by check_script",
+        "_pcntl - enabled by default in Debian package - not tested by check_script",
         "apcu",
         "curl",
         "exif",

--- a/versions_data/2023.06.json
+++ b/versions_data/2023.06.json
@@ -5,7 +5,7 @@
     "debian_version": 12,
     "faros_requirements": [
         "_opcache - not tested by check_script",
-        "_pcntl - not tested by check_script",
+        "_pcntl - enabled by default in Debian package - not tested by check_script",
         "apcu",
         "curl",
         "exif",

--- a/versions_data/2024.04.json
+++ b/versions_data/2024.04.json
@@ -5,7 +5,7 @@
     "debian_version": 12,
     "faros_requirements": [
         "_opcache - not tested by check_script",
-        "_pcntl - not tested by check_script",
+        "_pcntl - enabled by default in Debian package - not tested by check_script",
         "apcu",
         "curl",
         "exif",

--- a/versions_data/2024.07.json
+++ b/versions_data/2024.07.json
@@ -5,7 +5,7 @@
     "debian_version": 12,
     "faros_requirements": [
         "_opcache - not tested by check_script",
-        "_pcntl - not tested by check_script",
+        "_pcntl - enabled by default in Debian package - not tested by check_script",
         "apcu",
         "curl",
         "exif",

--- a/versions_data/9.0(2019.03).json
+++ b/versions_data/9.0(2019.03).json
@@ -5,7 +5,7 @@
     "debian_version": 9,
     "faros_requirements": [
         "_opcache - not tested by check_script",
-        "_pcntl - not tested by check_script",
+        "_pcntl - enabled by default in Debian package - not tested by check_script",
         "apcu",
         "curl",
         "exif",


### PR DESCRIPTION
**TLDR;** j'ai ajouté une note indiquant que l'extension est activée par défaut dans les packages Debian.

Dans le cadre de la configuration d'une nouvelle machine suivant les prérequis [2024.07](https://faros.lephare.com/docs/versions/2024.07.html#extensions), je me suis demandé pour quelle raison figurait l'extension PHP pcntl.

Cette extension n'est pas installable mais est [à activer lors du build de php](https://www.php.net/manual/en/pcntl.installation.php).

Debian package php avec pcntl activé. Cf. [code source](https://salsa.debian.org/php-team/php/-/blob/debian/main/8.3/debian/rules?ref_type=heads#L221)
Cette PR devrait résoudre cette issue https://github.com/le-phare/le-phare.github.io/issues/125

Cette extension est a priori utile pour symfony/messenger, je me suis demandé pourquoi cela ne figurait pas dans les dépendances symfony/messenger => parce que l'extension n'est pas disponible sur Windows et donc ce cas est géré. [Voir détails](https://github.com/symfony/symfony/pull/52129).

@thislg étant donné [cette issue](https://github.com/le-phare/le-phare.github.io/issues/175), dois-je update que la dernière version dans ce cas ?

@lucasmirloup je n'ai pas pu tester en local que je n'ai rien cassé sur le site car j'ai une erreur SSL
![Screenshot from 2024-09-06 10-35-39](https://github.com/user-attachments/assets/23c6ad57-b56e-4f91-b409-85fb3d4a0b8e)
Saurais-tu m'aider stp ?

