### PR TITLE
docs(network): add network to download cachetool

### DIFF
--- a/docs/static/configuration/network.md
+++ b/docs/static/configuration/network.md
@@ -17,6 +17,7 @@ permalink: /docs/config/network.html
 
 - github.com ([About GitHub's IP addresses](https://help.github.com/en/articles/about-githubs-ip-addresses))
 - raw.githubusercontent.com
+- gordalina.github.io
 - api.github.com
 - codeload.github.com
 - gitlab.com


### PR DESCRIPTION
lephare/ansible-deply uses
http://gordalina.github.io/cachetool/downloads/cachetool.phar to install cachetool during "LEPHARE - Install latest cachetool" task