### PR TITLE
docs(network): add network to download Adminer

### DIFF
--- a/docs/static/configuration/network.md
+++ b/docs/static/configuration/network.md
@@ -29,3 +29,4 @@ permalink: /docs/config/network.html
 - faros.lephare.com
 - hc-ping.com
 - api.pwnedpasswords.com
+- download.adminerevo.org


### PR DESCRIPTION
lephare/ansible-deploy uses
download.adminerevo.org to install adminer during "LEPHARE - install latest AdminerEvo" task

Related to https://github.com/le-phare/ansible-deploy/pull/64