### PR TITLE
docs(tutorial): clarify that one unique script is executed for 2 SAPI

### DIFF
--- a/docs/static/check-tutorial.md
+++ b/docs/static/check-tutorial.md
@@ -7,7 +7,12 @@ permalink: /check-tutorial
 
 # Introduction
 
-Pour garantir le bon fonctionnement de notre application dans différentes configurations PHP, nous fournissons deux versions de fichiers de test : une pour une exécution en ligne de commande (CLI) et une autre pour un déploiement via un serveur web (FPM).
+Pour garantir le bon fonctionnement de notre application, nous fournissons un même fichier de test à exécuter dans deux contextes : 
+
+- CLI : pour une exécution en ligne de commande; exemple: `php public/check_2024.07.php`
+- FPM : via un serveur web (APACHE/PHP-FPM); exemple: "https://monapp.com/check_2024.07.php"
+
+<em>Ces deux contextes correpondent à deux SAPI, qui ont chacun leur propre configuration PHP.</em>
 
 
 ## Avant de lancer les tests


### PR DESCRIPTION
Contexte: Rémy me demandait

>  petite question sur le guide des pré-requis hébergeur faros.
Dans la partie "tutoriel fichier de check", il est indiqué dans le premier paragraphe "Pour garantir le bon fonctionnement de notre application dans différentes configurations PHP, nous fournissons deux versions de fichiers de test : une pour une exécution en ligne de commande (CLI) et une autre pour un déploiement via un serveur web (FPM)."
Mais dans la page d'une version, on a qu'un seul fichier de test dispo (ex : check_2024.07.php)
Est-ce que c'est normal ?

J'ai revu avec lui le wording pour que ce soit plus clair.